### PR TITLE
Fix book reading crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# ignore game files not in the repository, but needed for
+# execution such as: renpy, lib, game music, and executables
+WT Silver.exe
+WT Silver.py
+lib/
+renpy/
+game/music/
+
+
 #################
 ## Eclipse
 #################
@@ -5,7 +14,6 @@
 *.pydevproject
 .project
 .metadata
-game/music/
 bin/
 tmp/
 *.mp3

--- a/game/00_hp_rpy/17_books.rpy
+++ b/game/00_hp_rpy/17_books.rpy
@@ -341,7 +341,7 @@ label handle_book_selection(BookOBJ):
         else:
             ">You already finished this one."
         hide screen gift
-        jump test_new_book
+        jump books_list
     else:
         menu:
             "-Read the book-":
@@ -370,7 +370,7 @@ label check_book_order(bookOBJ = None):
             call reading_book(BookOBJ)
     
     m "Reading books out of order won't do me any good."
-    jump test_new_book
+    jump books_list
     
     
 label reading_book(bookID = None):


### PR DESCRIPTION
The game crashed upon trying to read a book that has already been
red completely due to a jump to the undefined label `test_new_book`.
Not sure if there was something planned for this.