### PR TITLE
Gifts fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# ignore game files not in the repository, but needed for
+# execution such as: renpy, lib, game music, and executables
+WT Silver.exe
+WT Silver.py
+lib/
+renpy/
+game/music/
+
+
 #################
 ## Eclipse
 #################
@@ -5,7 +14,6 @@
 *.pydevproject
 .project
 .metadata
-game/music/
 bin/
 tmp/
 *.mp3

--- a/game/00_hp_rpy/00_HT_Persistant.rpy
+++ b/game/00_hp_rpy/00_HT_Persistant.rpy
@@ -182,8 +182,8 @@ label __init_variables:
         $ skip_duel = False
     if not hasattr(renpy.store,'next_day'): #important!
         $ next_day = False
-    if not hasattr(renpy.store,'order_item'): #important!
-        $ order_item = 0
+    if not hasattr(renpy.store,'gift_order'): #important!
+        $ gift_order = None
     if not hasattr(renpy.store,'order_quantity'): #important!
         $ order_quantity = 0
     if not hasattr(renpy.store,'force_unlock_pub_favors'): #important!

--- a/game/00_hp_rpy/15_mail.rpy
+++ b/game/00_hp_rpy/15_mail.rpy
@@ -216,7 +216,7 @@ label mail_02: #Packages only. <================================================
         $ package_is_here = False # Turns True when days_in_delivery >= 5. Package is displayed.
         $ days_in_delivery = 0 #Count's +1 every day when order_placed = True
         
-        $ gift_item_inv[gift_order.id+1] += order_quantity
+        $ gift_item_inv[gift_order.id] += order_quantity
         
         $ the_gift = gift_order.image
         show screen gift
@@ -231,29 +231,6 @@ label mail_02: #Packages only. <================================================
         hide screen gift
         with d3
         $ gift_order = None
-        call screen main_menu_01
-        
-        
- 
-    if order_item != 0:
-        $ package_is_here = False # Turns True when days_in_delivery >= 5. Package is displayed.
-        $ days_in_delivery = 0 #Count's +1 every day when order_placed = True
-        
-        $ gift_item_inv[order_item] += order_quantity
-
-        $ the_gift = "01_hp/18_store/gifts/"+str(order_item)+".png" # CONDOMS.
-        show screen gift
-        with d3
-        $ tmp_str = "\""+store_gift_item_name[order_item]
-        if order_quantity > 1:
-            $ tmp_str += "'s\""
-            ">([order_quantity]) [tmp_str] have been added to your possessions."
-        else:
-            $ tmp_str += "\""
-            ">([order_quantity]) [tmp_str] has been added to your possessions."
-        hide screen gift
-        with d3
-        $ order_item = 0
         call screen main_menu_01
         
     

--- a/game/00_hp_rpy/17_books.rpy
+++ b/game/00_hp_rpy/17_books.rpy
@@ -341,7 +341,7 @@ label handle_book_selection(BookOBJ):
         else:
             ">You already finished this one."
         hide screen gift
-        jump test_new_book
+        jump books_list
     else:
         menu:
             "-Read the book-":
@@ -370,7 +370,7 @@ label check_book_order(bookOBJ = None):
             call reading_book(BookOBJ)
     
     m "Reading books out of order won't do me any good."
-    jump test_new_book
+    jump books_list
     
     
 label reading_book(bookID = None):

--- a/game/00_hp_rpy/28_gifts.rpy
+++ b/game/00_hp_rpy/28_gifts.rpy
@@ -104,7 +104,7 @@ label __init_variables:
     
     if not hasattr(renpy.store,'PackOfCondoms'): #important!
         $ PackOfCondoms = gift_item()
-    $ PackOfCondoms.id = 0
+    $ PackOfCondoms.id = 10
     $ PackOfCondoms.cost = 50
     $ PackOfCondoms.whoringNeeded = 3
     $ PackOfCondoms.name = "A pack of condoms"
@@ -113,7 +113,7 @@ label __init_variables:
     
     if not hasattr(renpy.store,'Vibrator'): #important!
         $ Vibrator = gift_item()
-    $ Vibrator.id = 10
+    $ Vibrator.id = 11
     $ Vibrator.cost = 55
     $ Vibrator.whoringNeeded = 3
     $ Vibrator.name = "Vibrator"
@@ -122,7 +122,7 @@ label __init_variables:
     
     if not hasattr(renpy.store,'JarOfLube'): #important!
         $ JarOfLube = gift_item()
-    $ JarOfLube.id = 11
+    $ JarOfLube.id = 12
     $ JarOfLube.cost = 60
     $ JarOfLube.name = "Jar of anal lubricant"
     $ JarOfLube.image = "01_hp/18_store/gifts/13.png"
@@ -130,7 +130,7 @@ label __init_variables:
     
     if not hasattr(renpy.store,'BallGagAndCuffs'): #important!
         $ BallGagAndCuffs = gift_item()
-    $ BallGagAndCuffs.id = 12
+    $ BallGagAndCuffs.id = 13
     $ BallGagAndCuffs.cost = 70
     $ BallGagAndCuffs.name = "Ball gag and cuffs"
     $ BallGagAndCuffs.image = "01_hp/18_store/gifts/14.png"
@@ -138,7 +138,7 @@ label __init_variables:
     
     if not hasattr(renpy.store,'AnalPlugs'): #important!
         $ AnalPlugs = gift_item()
-    $ AnalPlugs.id = 13
+    $ AnalPlugs.id = 14
     $ AnalPlugs.cost = 85
     $ AnalPlugs.whoringNeeded = 3
     $ AnalPlugs.name = "Anal plugs"
@@ -147,7 +147,7 @@ label __init_variables:
     
     if not hasattr(renpy.store,'ThestralStrapon'): #important!
         $ ThestralStrapon = gift_item()
-    $ ThestralStrapon.id = 14
+    $ ThestralStrapon.id = 15
     $ ThestralStrapon.cost = 200
     $ ThestralStrapon.whoringNeeded = 3
     $ ThestralStrapon.name = "Thestral Strap-on"
@@ -156,7 +156,7 @@ label __init_variables:
     
     if not hasattr(renpy.store,'SpeedStick2000'): #important!
         $ SpeedStick2000 = gift_item()
-    $ SpeedStick2000.id = 15
+    $ SpeedStick2000.id = 16
     $ SpeedStick2000.cost = 500
     $ SpeedStick2000.name = "Lady Speed Stick-2000"
     $ SpeedStick2000.image = "01_hp/18_store/gifts/17.png"
@@ -164,7 +164,7 @@ label __init_variables:
     
     if not hasattr(renpy.store,'SexDollJoanne'): #important!
         $ SexDollJoanne = gift_item()
-    $ SexDollJoanne.id = 16
+    $ SexDollJoanne.id = 17
     $ SexDollJoanne.cost = 350
     $ SexDollJoanne.name = "Sex doll \"Joanne\""
     $ SexDollJoanne.image = "01_hp/18_store/gifts/18.png"
@@ -172,7 +172,7 @@ label __init_variables:
     
     if not hasattr(renpy.store,'AnalBeads'): #important!
         $ AnalBeads = gift_item()
-    $ AnalBeads.id = 17
+    $ AnalBeads.id = 18
     $ AnalBeads.cost = 65 #placeholder number
     $ AnalBeads.name = "Anal beads"
     $ AnalBeads.image = "01_hp/18_store/gift_anal_beads.png"

--- a/game/00_hp_rpy/28_gifts.rpy
+++ b/game/00_hp_rpy/28_gifts.rpy
@@ -247,7 +247,7 @@ label give_her_gift(gift_id):
     with d5
     $ h_xpos=140 #Defines position of the Hermione's full length sprite. (Default 370). (Center: 140)
     
-    if gift_id == 1:#candy
+    if gift_id == 0:#candy
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("A lollipop?","body_01")
             call give_gift(">You give the candy to Hermione...",gift_id)
@@ -273,7 +273,7 @@ label give_her_gift(gift_id):
             call her_main("Thank you, [genie_name].","body_74")
             call happy(5)
             $ h_body = "body_128"
-    if gift_id == 2:#chocolate
+    if gift_id == 1:#chocolate
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("A chocolate bar?","body_01")
             call give_gift(">You give the chocolate to Hermione...", gift_id)
@@ -299,7 +299,7 @@ label give_her_gift(gift_id):
             call give_gift(">You give the chocolate to Hermione...", gift_id)
             call her_main("Thank you.","body_129")
             call happy(10)
-    if gift_id == 3:#plush owl
+    if gift_id == 2:#plush owl
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("A stuffed owl?","body_01")
             call her_main("It's cute...","body_06")
@@ -330,7 +330,7 @@ label give_her_gift(gift_id):
             call give_gift(">You give the owl to Hermione...",gift_id)
             $ h_body = "body_01"
             call happy(4)
-    if gift_id == 4:#butterbeer
+    if gift_id == 3:#butterbeer
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("Butterbeer?","body_01")
             call her_main("Are you sure about that, [genie_name]?","body_08")
@@ -359,7 +359,7 @@ label give_her_gift(gift_id):
             call her_main("Err... I meant to say with the girls, of course.","body_189")
             call happy(20)
             $ h_body = "body_01"
-    if gift_id == 5:#edu mags
+    if gift_id == 4:#edu mags
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("\"Popular magic\" magazines?","body_01")
             call give_gift(">You give an assortment of educational magazines to Hermione...",gift_id)
@@ -386,7 +386,7 @@ label give_her_gift(gift_id):
             call give_gift(">You give an assortment of educational magazines to Hermione...",gift_id)
             call her_main("Thank you.","body_13")
             call no_change 
-    if gift_id == 6:#girl mags
+    if gift_id == 5:#girl mags
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("Hm?","body_15")
             call her_main("This is the sort of press some \"slytherin\" bimbo would appreciate.","body_17")
@@ -415,7 +415,7 @@ label give_her_gift(gift_id):
             call her_main("Thank you, [genie_name].","body_08")
             call happy(15)
             $ h_body = "body_06"
-    if gift_id == 7:#adult mags
+    if gift_id == 6:#adult mags
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("Are that...?","body_02")
             call her_main("Adult magazines, [genie_name]?","body_31")
@@ -444,7 +444,7 @@ label give_her_gift(gift_id):
             call give_gift(">You give an assortment of adult magazines to Hermione...",gift_id)
             call her_main("thank you, [genie_name].","body_74")
             call happy(15)
-    if gift_id == 8:#porn mags
+    if gift_id == 7:#porn mags
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("Hm... What is this?","body_01")
             call her_main("[genie_name], those are porn magazines!","body_130")
@@ -476,7 +476,7 @@ label give_her_gift(gift_id):
             call give_gift(">You give an assortment of porn magazines to Hermione...",gift_id)
             call happy(15)
             $ h_body = "body_45"
-    if gift_id == 9:#krum poster
+    if gift_id == 8:#krum poster
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("A Quidditch poster?","body_73")
             call her_main("What am I supposed to do with it, [genie_name]?","body_185")
@@ -503,7 +503,7 @@ label give_her_gift(gift_id):
             call her_main("Can't wait to hang it over my bed!","body_46")
             call her_main("The girls will go green with envy...","body_64")
             call happy(25)
-    if gift_id == 10:#lingerie
+    if gift_id == 9:#lingerie
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("lingerie?","body_118")
             call her_main("[genie_name], I cannot accept a gift like this from you...","body_120")
@@ -525,7 +525,7 @@ label give_her_gift(gift_id):
             call her_main("Oh... I mean, thank you, [genie_name].","body_122")
             call give_gift(">You give the lingerie to Hermione...",gift_id)
             call happy(15)
-    if gift_id == 11:#condoms
+    if gift_id == 10:#condoms
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("Condoms?!","body_18")
             call her_main("[genie_name], I wouldn't even know what to do with them...","body_30")
@@ -549,7 +549,7 @@ label give_her_gift(gift_id):
             call give_gift(">You give a pack of condoms to Hermione...", gift_id)
             call happy(4)
             $ h_body = "body_45"
-    if gift_id == 12:#vibrator
+    if gift_id == 11:#vibrator
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("A magic wand?","body_01")
             call her_main("No, it doesn't look like--","body_15")
@@ -580,7 +580,7 @@ label give_her_gift(gift_id):
             call give_gift(">You give the vibrator to Hermione...",gift_id)
             call her_main("Thank you, [genie_name].","body_124")
             call happy(10)
-    if gift_id == 13:#anal lube
+    if gift_id == 12:#anal lube
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("I don't know what this is...","body_02")
             call her_main("But I have the feeling that the jar is full of something vile and inappropriate...","body_05")
@@ -608,7 +608,7 @@ label give_her_gift(gift_id):
             call her_main("Thank for looking out for us, [genie_name].","body_128")
             call give_gift(">You give the jar to Hermione...", gift_id)
             call happy(5)
-    if gift_id == 14:#gag and cuffs
+    if gift_id == 13:#gag and cuffs
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("What is this?","body_118")
             call her_main("Is this like one of those adult toys?","body_141")
@@ -638,7 +638,7 @@ label give_her_gift(gift_id):
             call her_main("But a gift is a gift, right?","body_129")
             call give_gift(">You give the ball gag and cuffs to Hermione...",gift_id)
             call happy(15)
-    if gift_id == 15:#anal plugs
+    if gift_id == 14:#anal plugs
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("Hm...?","body_01")
             call her_main("Are those like key-chain toys?","body_15")
@@ -667,7 +667,7 @@ label give_her_gift(gift_id):
             call her_main("But I shall never use them of course...","body_127")
             call her_main("................","body_124")
             call happy(10)
-    if gift_id == 16:#strap on
+    if gift_id == 15:#strap on
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("What is that?","body_18")
             call her_main("An artifact of some sort or a trophy?","body_14")
@@ -708,7 +708,7 @@ label give_her_gift(gift_id):
             call give_gift(">You give the strap-on to Hermione...",gift_id)
             call her_main("Thank you for the gift, [genie_name].","body_129")
             call happy(30)
-    if gift_id == 17:#speed stick
+    if gift_id == 16:#speed stick
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("A broom...?","body_01")
             call her_main("Hm...","body_03")
@@ -745,7 +745,7 @@ label give_her_gift(gift_id):
             call give_gift(">You give the broom to Hermione...",gift_id)
             call her_main("Thank you, [genie_name].","body_128")
             call happy(30)
-    if gift_id == 18:#sex doll
+    if gift_id == 17:#sex doll
         if whoring >= 0 and whoring <= 5: # Lv 1-2.
             call her_main("Is this...","body_48")
             call her_main("A sex doll?!","body_34")
@@ -779,7 +779,9 @@ label give_her_gift(gift_id):
 label give_gift(text = "", gift = 0):
     hide screen hermione_main
     with d3
-    $ the_gift = "01_hp/18_store/gifts/"+str(gift)+".png"
+    # note that gift is the index (starting with 0), while the image
+    # files are starting with/off by 1!
+    $ the_gift = "01_hp/18_store/gifts/"+str(gift+1)+".png"
     show screen gift
     with d3
     "[text]"
@@ -787,82 +789,6 @@ label give_gift(text = "", gift = 0):
     with d3
     $ gift_item_inv[gift] -= 1
     return
-    
-label display_gift(text=">Gift given", gift_id):
-    hide screen hermione_main
-    with d3
-    $ the_gift = "01_hp/18_store/gifts/"+str(gift_id)+".png"
-    show screen gift
-    with d3
-    "[text]"
-    hide screen gift
-    with d3
-    return
-    
-label give_her_existing_stock(stock_id):
-    hide screen hermione_main
-    with d5
-    $ hermione_xpos = 140
-    
-    if stock_id == "fishnet_stockings":
-        call her_main("A pair of stockings?","body_03")
-        call display_gift(">You give the stockings to Hermione...\n>Fishnet stockings have been added to the wardrobe.","30")
-        call her_main("Thank you, [genie_name].","body_04")
-        $ cs_existing_stock_gifted.append("fishnet_stockings")
-        call happy(30)
-    if stock_id == "gryffindor_stockings":
-        call her_main("A pair of stockings?","body_03")
-        call display_gift(">You give the stockings to Hermione...\n>gryffindor stockings have been added to the wardrobe.","07")
-        $ cs_existing_stock_gifted.append("gryffindor_stockings")
-        call her_main("Thank you, [genie_name].","body_04")
-        call happy(30)
-    if stock_id == "SPEW_badge":
-        call her_main("A badge?","body_01")
-        call display_gift(">You give the badge to Hermione...\n>The \"S.P.E.W. badge has been added to the wardrobe.","29")
-        $ cs_existing_stock_gifted.append("SPEW_badge")
-        call her_main("Thank you, [genie_name].","body_06")
-        call happy(30)
-    if stock_id == "jeans_long":
-        call her_main("A pair of jeans?","body_03")
-        call display_gift(">You give the jeans to Hermione...\n>jeans have been added to the wardrobe.","07")
-        $ cs_existing_stock_gifted.append("jeans_long")
-        call her_main("Thank you, [genie_name].","body_04")
-        call happy(30)
-    if stock_id == "short_jeans":
-        call her_main("A pair of daisy dukes?","body_03")
-        call display_gift(">You give the daisy dukes to Hermione...\n>short jeans have been added to the wardrobe.","07")
-        $ cs_existing_stock_gifted.append("short_jeans")
-        call her_main("Thank you, [genie_name].","body_04")
-        call happy(30)
-    if stock_id == "lace_set":
-        call her_main("A set of undergarments?","body_03")
-        call display_gift(">You give the lace bra and panties to Hermione...\n>lace bra and panties have been added to the wardrobe.","07")
-        $ cs_existing_stock_gifted.append("lace_set")
-        call her_main("Thank you, [genie_name].","body_04")
-        call happy(30)
-    if stock_id == "cup_set":
-        call her_main("A set of undergarments??","body_03")
-        call display_gift(">You give the cup bra and panties to Hermione...\n>cup bra and panties have been added to the wardrobe.","07")
-        $ cs_existing_stock_gifted.append("cup_set")
-        call her_main("Thank you, [genie_name].","body_04")
-        call happy(30)
-    if stock_id == "silk_set":
-        call her_main("A set of undergarments?","body_03")
-        call display_gift(">You give the silk bra and panties to Hermione...\n>silk bra and panties have been added to the wardrobe.","07")
-        $ cs_existing_stock_gifted.append("silk_set")
-        call her_main("Thank you, [genie_name].","body_04")
-        call happy(30)
-    if stock_id == "ITEM_ID":
-        call her_main("HERMIONE_QUESTIONS_ITEM?","body_03")
-        call display_gift(">You give the ITEM to Hermione...\n>ITEM have been added to the wardrobe.","07")
-        $ cs_existing_stock_gifted.append("ITEM_ID")
-        call her_main("Thank you, [genie_name].","body_04")
-        call happy(30)
-        
-    $ hermione_xpos = 370 #Defines position of the Hermione's full length sprite. (Default 370). (Center: 140)
-    show screen hermione_main
-    with d3
-    jump day_time_requests 
     
     
 ###GIVING CLOTHING RESPONSES

--- a/game/00_hp_rpy/38_wardrobe.rpy
+++ b/game/00_hp_rpy/38_wardrobe.rpy
@@ -192,7 +192,7 @@ screen wardrobe_gifts:
         
         # note that gift_items are indices (starting with 0) but the
         # image files are starting with/off by 1.
-        for i in range(0,17):
+        for i in range(0,18):
             $ row = i // 6
             $ col = i % 6
             if gift_item_inv[i] > 0:

--- a/game/00_hp_rpy/38_wardrobe.rpy
+++ b/game/00_hp_rpy/38_wardrobe.rpy
@@ -190,25 +190,16 @@ screen wardrobe_gifts:
         hotspot (391, 30, 67, 82) clicked Show("wardrobe_underwear")
         hotspot (480, 30, 67, 82) clicked Show("wardrobe_gifts")
         
-        for i in range(0,6):
-            if gift_item_inv[i+1] > 0:
-                hotspot ((21+(90*i)), 140, 83, 85) clicked [SetVariable("wardrobe_gift_item",i+1),Jump("wardrobe_give_gift")]
-        for i in range(0,6):
-            if gift_item_inv[i+7] > 0:
-                hotspot ((21+(90*i)), 232, 83, 85) clicked [SetVariable("wardrobe_gift_item",i+7),Jump("wardrobe_give_gift")]
-        for i in range(0,6):
-            if gift_item_inv[i+13] > 0:
-                hotspot ((21+(90*i)), 324, 83, 85) clicked [SetVariable("wardrobe_gift_item",i+13),Jump("wardrobe_give_gift")]
-        
-        for i in range(1,7):
-            add "01_hp/18_store/gifts/"+str(i)+".png" xpos -150+(90*i) ypos 90 zoom 0.30
-            text str(gift_item_inv[i]) xpos -70+(90*i) ypos 210 
-        for i in range(7,13):
-            add "01_hp/18_store/gifts/"+str(i)+".png" xpos -150+(90*(i-6)) ypos 180 zoom 0.30
-            text str(gift_item_inv[i]) xpos -70+(90*(i-6)) ypos 300
-        for i in range(13,18):
-            add "01_hp/18_store/gifts/"+str(i)+".png" xpos -150+(90*(i-12)) ypos 270 zoom 0.30
-            text str(gift_item_inv[i]) xpos -70+(90*(i-12)) ypos 390 
+        # note that gift_items are indices (starting with 0) but the
+        # image files are starting with/off by 1.
+        for i in range(0,17):
+            $ row = i // 6
+            $ col = i % 6
+            if gift_item_inv[i] > 0:
+                hotspot ((21+(90*col)), (140+(92*row)), 83, 85) clicked [SetVariable("wardrobe_gift_item",i),Jump("wardrobe_give_gift")]
+            add "01_hp/18_store/gifts/"+str(i+1)+".png" xpos -60+(90*col) ypos (90+(90*row)) zoom 0.30
+            text str(gift_item_inv[i]) xpos 20+(90*col) ypos (210+(90*row))
+
 
         #Adding custom one off items (Collar, dress, stockings)
 

--- a/game/00_hp_rpy/the_oddities.rpy
+++ b/game/00_hp_rpy/the_oddities.rpy
@@ -443,7 +443,6 @@ label object_purchase_item(order_cost):
         call thx_4_shoping
         jump shop_menu
     else:
-        $ order_item = 0
         call no_gold #Massage: m "I don't have enough gold".
         jump gifts_menu
     

--- a/game/00_hp_rpy/ue_tutoring.rpy
+++ b/game/00_hp_rpy/ue_tutoring.rpy
@@ -19,17 +19,17 @@ label l_tutoring_check:
         else:
             m "I need to buy adult magazines for this lesson."
     elif v_tutoring == 8 and whoring >= 17:
-        if gift_item_inv[8] >= 1:# Porn magazines
+        if gift_item_inv[7] >= 1:# Porn magazines
             jump l_tutoring
         else:
             m "I need to buy porn magazines for this lesson."
     elif v_tutoring == 9 and whoring >= 20:
-        if gift_item_inv[12] >= 1:# Vibrator
+        if gift_item_inv[11] >= 1:# Vibrator
             jump l_tutoring
         else:
             m "I need to buy a vibrator for this lesson."
     elif v_tutoring == 10 and whoring >= 23:
-        if gift_item_inv[15] >= 1:# Anal plugs
+        if gift_item_inv[14] >= 1:# Anal plugs
             jump l_tutoring
         else:
             m "I need to buy anal plugs for this lesson."


### PR DESCRIPTION
Fixes gifts (buying, gifting, or as prerequisites, e.g. for tutoring). Gift items in code should always be referred to by index (starting with 0). Only the image files/file names use a position starting with/off by 1.