### PR TITLE
Update 11_cupboard.rpy

### DIFF
--- a/game/00_hp_rpy/11_cupboard.rpy
+++ b/game/00_hp_rpy/11_cupboard.rpy
@@ -163,8 +163,8 @@ label cupboard:
         "-Cheat-":
             jump cheats_ht
 
-        "-Toggle Player Guide-":
-            jump toggle_guide_icon
+        "-Reset Hermione's Clothes-": #label in wardrobe_labels.rpy
+            jump reset_hermione_clothes
         
         "-Never mind-":
             jump day_main_menu


### PR DESCRIPTION
clothing reset button for wardrobe.
Removed obsolete guide icon (since it's now bound to main_menu_01)